### PR TITLE
feat: New events endpoints

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -98,7 +98,6 @@ tags:
 
 servers:
   - url: "https://www.zenduty.com"
-
 security:
   - bearerAuth: []
 
@@ -7239,6 +7238,8 @@ paths:
                 detail: Not Found.
                 
   "/integration/{account_id}/generic/{integration_key}/":
+    servers:
+      - url: https://events.zenduty.com
     parameters:
       - name: "account_id"
         in: path
@@ -7340,6 +7341,8 @@ paths:
                 detail: Not Found.
   
   "/api/alert/status/{trace_id}/":
+    servers:
+      - url: https://events.zenduty.com
     parameters:
       - name: "trace_id"
         in: path

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -7085,6 +7085,7 @@ paths:
           type: string
         required: true
     post:
+      deprecated: true  
       tags:
         - Events
       summary: Create the Event object
@@ -7236,7 +7237,214 @@ paths:
             application/xml:
               example:
                 detail: Not Found.
-
+                
+  "/api/v3/events/{integration_key}/":
+    parameters:
+      - name: "integration_key"
+        in: path
+        description: integration_key of the Integration object
+        schema:
+          type: string
+        required: true
+    post:
+      tags:
+        - Events
+      summary: Create the Event object
+      description: Create the Event object by setting the values of all the required parameters passed in the request body.
+      requestBody:
+        description: Request body parameters to create the Event object
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventPayload"
+            example:
+              alert_type: info
+              message: This is info alert
+              summary: This is the incident summary
+              entity_id: 12345
+              payload:
+                {
+                  "status": "ACME Payments are failing",
+                  "severity": "1",
+                  "project": "kubeprod",
+                }
+              urls:
+                [
+                  {
+                    "link_url": "https://www.example.com/alerts/12345/",
+                    "link_text": "Alert URL",
+                  },
+                ]
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/EventPayload"
+            example:
+              alert_type: info
+              message: This is info alert
+              summary: This is the incident summary
+              entity_id: 12345
+              payload:
+                {
+                  "status": "ACME Payments are failing",
+                  "severity": "1",
+                  "project": "kubeprod",
+                }
+              urls:
+                [
+                  {
+                    "link_url": "https://www.example.com/alerts/1234/",
+                    "link_text": "Alert URL",
+                  },
+                ]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventV3"
+              example:
+                message: "success"
+                trace_id: "174f924aeb6ef4c944e20ebb9d71c2db"
+                
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/EventV3"
+              example:
+                message: "success"
+                trace_id: "174f924aeb6ef4c944e20ebb9d71c2db"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              example:
+                error: This request can not be processed.
+            application/xml:
+              example:
+                error: This request can not be processed.
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              example:
+                detail: Not Found.
+            application/xml:
+              example:
+                detail: Not Found.
+  
+  "/api/events/status/{trace_id}/":
+    parameters:
+      - name: "trace_id"
+        in: path
+        description: trace id of the alert object
+        schema:
+          type: string
+        required: true
+    get:
+      tags:
+        - Events
+      summary: Get the status of an Alert
+      description: Get the Alert object for specific trace id.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertStatus"
+              example:
+                status: "completed"
+                alert:
+                  integration_object:
+                    name: "API"
+                    creation_date: "2022-11-14T14:08:56.089450Z"
+                    summary: "Zenduty API integration"
+                    unique_id: "828361de-681f-4f00-9420-07a185a83e46"
+                    service: "1587103f-6ed2-4eac-8a56-866128df036f"
+                    team: "db61f7ed-ba78-4536-9b2d-256b135a731d"
+                    integration_key: "082a1af8-064c-40a2-a99c-bc9c27d2042d"
+                    is_enabled: true
+                    integration_type: 0
+                  summary: "This is the incident summary"
+                  incident: null
+                  creation_date: "2023-04-05T12:40:35.405170Z"
+                  message: "This is info alert"
+                  integration: "828361de-681f-4f00-9420-07a185a83e46"
+                  suppressed: false
+                  entity_id: "12345"
+                  payload: {}
+                  alert_type: "0"
+                  unique_id: "hD5dKNDyFDVADEYdrLViM7"
+                  images: []
+                  urls:
+                    [
+                      {
+                        "unique_id": "b7cc93a2-6f64-46c6-bed7-2dd0504917f6",
+                        "link_url": "https://www.example.com/alerts/1234/",
+                        "link_text": "Alert URL",
+                      },
+                    ]
+                  notes: []
+                  incident_created: false
+                error: ""
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/AlertStatus"
+              example:
+                status: "completed"
+                alert:
+                  integration_object:
+                    name: "API"
+                    creation_date: "2022-11-14T14:08:56.089450Z"
+                    summary: "Zenduty API integration"
+                    unique_id: "828361de-681f-4f00-9420-07a185a83e46"
+                    service: "1587103f-6ed2-4eac-8a56-866128df036f"
+                    team: "db61f7ed-ba78-4536-9b2d-256b135a731d"
+                    integration_key: "082a1af8-064c-40a2-a99c-bc9c27d2042d"
+                    is_enabled: true
+                    integration_type: 0
+                  summary: "This is the incident summary"
+                  incident: null
+                  creation_date: "2023-04-05T12:40:35.405170Z"
+                  message: "This is info alert"
+                  integration: "828361de-681f-4f00-9420-07a185a83e46"
+                  suppressed: false
+                  entity_id: "12345"
+                  payload: {}
+                  alert_type: "0"
+                  unique_id: "hD5dKNDyFDVADEYdrLViM7"
+                  images: []
+                  urls:
+                    [
+                      {
+                        "unique_id": "b7cc93a2-6f64-46c6-bed7-2dd0504917f6",
+                        "link_url": "https://www.example.com/alerts/1234/",
+                        "link_text": "Alert URL",
+                      },
+                    ]
+                  notes: []
+                  incident_created: false
+                error: ""
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example:
+                detail: You do not have permission to perform this action.
+            application/xml:
+              example:
+                detail: You do not have permission to perform this action.
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              example:
+                detail: Not Found.
+            application/xml:
+              example:
+                detail: Not Found.
+              
   "/api/incidents/{incident_number}/alerts/":
     parameters:
       - name: "incident_number"
@@ -13257,6 +13465,32 @@ components:
         incident_created:
           type: boolean
           description: A boolean flag that represents whether the Incident Alert object created an incident or not.
+    
+    EventV3:
+      type: object
+      description: Event object schema
+      properties:
+        message: 
+          description: success if alert processed successfully
+          type: string
+        trace_id: 
+          description: unique id to trace an alert
+          type: string
+    AlertStatus:
+      type: object
+      description: Alert Status object schema
+      properties:
+        status:
+          description: Status of an Alert. Possible statuses are queued, in-progress, completed and failed
+          type: string
+        alert:
+          description: Alert Object schema
+          type: object
+          items:
+            $ref: "#/components/schemas/Event"
+        error:
+          description: short error message if any error in alert creation
+          type: object
 
     EventPayload:
       type: object

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -7238,8 +7238,14 @@ paths:
               example:
                 detail: Not Found.
                 
-  "/api/v3/events/{integration_key}/":
+  "/integration/{account_id}/generic/{integration_key}/":
     parameters:
+      - name: "account_id"
+        in: path
+        description: 5 character long account identifier
+        schema:
+          type: string
+        required: true
       - name: "integration_key"
         in: path
         description: integration_key of the Integration object
@@ -7306,7 +7312,7 @@ paths:
                 $ref: "#/components/schemas/EventV3"
               example:
                 message: "success"
-                trace_id: "174f924aeb6ef4c944e20ebb9d71c2db"
+                trace_id: "2f7c427c-3dd4-4bfc-84c5-74a1fb936df7"
                 
             application/xml:
               schema:
@@ -7333,7 +7339,7 @@ paths:
               example:
                 detail: Not Found.
   
-  "/api/events/status/{trace_id}/":
+  "/api/alert/status/{trace_id}/":
     parameters:
       - name: "trace_id"
         in: path
@@ -7355,77 +7361,28 @@ paths:
                 $ref: "#/components/schemas/AlertStatus"
               example:
                 status: "completed"
-                alert:
-                  integration_object:
-                    name: "API"
-                    creation_date: "2022-11-14T14:08:56.089450Z"
-                    summary: "Zenduty API integration"
-                    unique_id: "828361de-681f-4f00-9420-07a185a83e46"
-                    service: "1587103f-6ed2-4eac-8a56-866128df036f"
-                    team: "db61f7ed-ba78-4536-9b2d-256b135a731d"
-                    integration_key: "082a1af8-064c-40a2-a99c-bc9c27d2042d"
-                    is_enabled: true
-                    integration_type: 0
-                  summary: "This is the incident summary"
-                  incident: null
-                  creation_date: "2023-04-05T12:40:35.405170Z"
-                  message: "This is info alert"
-                  integration: "828361de-681f-4f00-9420-07a185a83e46"
-                  suppressed: false
-                  entity_id: "12345"
-                  payload: {}
-                  alert_type: "0"
-                  unique_id: "hD5dKNDyFDVADEYdrLViM7"
-                  images: []
-                  urls:
-                    [
-                      {
-                        "unique_id": "b7cc93a2-6f64-46c6-bed7-2dd0504917f6",
-                        "link_url": "https://www.example.com/alerts/1234/",
-                        "link_text": "Alert URL",
-                      },
-                    ]
-                  notes: []
-                  incident_created: false
-                error: ""
+                alert: "JVPDBpGdpBQgRKdTGz2Qir"
+                integration:
+                  name: "API"
+                incident:
+                  incident_number: 123
+                  unique_id: "22cWPt3h3REvZCkHVHNsfm"
+                suppressed: false
+                is_incident_created: false
+                
             application/xml:
               schema:
                 $ref: "#/components/schemas/AlertStatus"
               example:
                 status: "completed"
-                alert:
-                  integration_object:
-                    name: "API"
-                    creation_date: "2022-11-14T14:08:56.089450Z"
-                    summary: "Zenduty API integration"
-                    unique_id: "828361de-681f-4f00-9420-07a185a83e46"
-                    service: "1587103f-6ed2-4eac-8a56-866128df036f"
-                    team: "db61f7ed-ba78-4536-9b2d-256b135a731d"
-                    integration_key: "082a1af8-064c-40a2-a99c-bc9c27d2042d"
-                    is_enabled: true
-                    integration_type: 0
-                  summary: "This is the incident summary"
-                  incident: null
-                  creation_date: "2023-04-05T12:40:35.405170Z"
-                  message: "This is info alert"
-                  integration: "828361de-681f-4f00-9420-07a185a83e46"
-                  suppressed: false
-                  entity_id: "12345"
-                  payload: {}
-                  alert_type: "0"
-                  unique_id: "hD5dKNDyFDVADEYdrLViM7"
-                  images: []
-                  urls:
-                    [
-                      {
-                        "unique_id": "b7cc93a2-6f64-46c6-bed7-2dd0504917f6",
-                        "link_url": "https://www.example.com/alerts/1234/",
-                        "link_text": "Alert URL",
-                      },
-                    ]
-                  notes: []
-                  incident_created: false
-                error: ""
+                alert: "JVPDBpGdpBQgRKdTGz2Qir"
+                integration:
+                  name: "API"
+                incident:
+                  incident_number: 123
+                  unique_id: "22cWPt3h3REvZCkHVHNsfm"
+                suppressed: false
+                is_incident_created: false
         "403":
           description: Forbidden
           content:
@@ -13481,17 +13438,41 @@ components:
       description: Alert Status object schema
       properties:
         status:
-          description: Status of an Alert. Possible statuses are queued, in-progress, completed and failed
+          description: Status of an Alert. Possible statuses are queued, completed and failed
           type: string
         alert:
-          description: Alert Object schema
-          type: object
-          items:
-            $ref: "#/components/schemas/Event"
+          description: unique_id of an alert object
+          type: string
+        integration:
+          $ref: "#/components/schemas/AlertStatusIntegration"
+        incident:
+          $ref: "#/components/schemas/AlertStatusIncident"
+        is_incident_created:
+          type: boolean
+          description: A boolean flag that represents whether the Incident Alert object created an incident or not.
+        suppressed:
+          type: boolean
+          description: A boolean flag that represents whether the Event object is suppressed or not
         error:
           description: short error message if any error in alert creation
-          type: object
-
+          type: string
+    AlertStatusIntegration:
+      type: object
+      description: Integration schema for Alert Status object
+      properties:
+        name:
+          type: string
+          description: A string that represents the name of an Integration object
+    AlertStatusIncident:
+      type: object
+      description: Incident schema for Alert Status object
+      properties:
+        incident_number:
+          type: integer
+          description: A integer that represents the number of an Incident object
+        unique_id:
+          type: string
+          description: A string that represents the unique_id of an Incident object
     EventPayload:
       type: object
       description: Payload schema for the Event object


### PR DESCRIPTION
- Introduces new events endpoint which points to kafka and returns only message and trace id in response. 
-  Introduces another new endpoint to check the status of the alert based on the trace id. 
-  New Events flow would be like
   - Make requests to new events endpoint
   - Get trace id from the response
   - Poll status of an alert from get status endpoint