### PR TITLE
fix maintenance post payload example

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -8773,8 +8773,7 @@ paths:
             example:
               name: New Infra Team Maintenance
               services:
-                - unique_id: 9b5a0301-3325-49b6-b54c-71d79a50c82d
-                  service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
+                - service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
               start_time: "2022-07-08T18:06:00Z"
               end_time: "2022-07-15T18:06:00Z"
           application/xml:
@@ -8783,8 +8782,7 @@ paths:
             example:
               name: New Infra Team Maintenance
               services:
-                - unique_id: 9b5a0301-3325-49b6-b54c-71d79a50c82d
-                  service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
+                - service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
               start_time: "2022-07-08T18:06:00Z"
               end_time: "2022-07-15T18:06:00Z"
       responses:
@@ -9032,8 +9030,7 @@ paths:
             example:
               name: Modified Infra Team Maintenance
               services:
-                - unique_id: 9b5a0301-3325-49b6-b54c-71d79a50c82d
-                  service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
+                - service: 191f5e2c-515e-4ee0-b501-3a292f8dae2f
               start_time: "2022-07-08T18:06:00Z"
               end_time: "2022-07-15T18:06:00Z"
       responses:


### PR DESCRIPTION
## Summary
- Remove `unique_id` from the `services[]` list in the Team Maintenance Mode POST and PUT request body examples
- Aligns the examples with the `TMMPayload` schema (only `service` is expected in the request body; `unique_id` is system-generated and only present in responses)

## Test plan
- [ ] `npm test` passes (spec validation)
- [ ] Verify rendered docs show the corrected POST/PUT example for `/api/account/teams/{}/maintenance/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)